### PR TITLE
Revert "Add proofs for quantifier identities"

### DIFF
--- a/sessions.yaml
+++ b/sessions.yaml
@@ -207,10 +207,6 @@
     conclusions: ["∃y.∃x.P(x,y)"]
   - assumptions: ["∃x.∀y.P(x,y)"]
     conclusions: ["∀y.∃x.P(x,y)"]
-  - assumptions: ["∀x.P(x)"]
-    conclusions: ["(∃x.P(x)→⊥)→⊥"]
-  - assumptions: ["(∀x.P(x))→⊥"]
-    conclusions: ["∃x.P(x)→⊥"]
   - assumptions: ["(∀x.P(x))→A"]
     conclusions: ["∃x.P(x)→A"]
 - name: Session 7


### PR DESCRIPTION
This reverts commit 6b84caef09111f7c35f767297408d7dd2daa3691.
